### PR TITLE
fix dependency resolution 

### DIFF
--- a/millbundler/src/io/github/nafg/millbundler/ScalaJSRollupModule.scala
+++ b/millbundler/src/io/github/nafg/millbundler/ScalaJSRollupModule.scala
@@ -4,6 +4,7 @@ import io.github.nafg.millbundler.jsdeps.JsDeps
 
 import mill.api.PathRef
 import mill.*
+import scala.compiletime.ops.double
 
 //noinspection ScalaWeakerAccess
 trait ScalaJSRollupModule extends ScalaJSBundleModule {
@@ -41,14 +42,15 @@ trait ScalaJSRollupModule extends ScalaJSBundleModule {
   override protected def bundle = Task.Anon { (params: BundleParams) =>
     val copied = copyInputFile.apply()(params.inputFiles)
 
-    val rollupPath =
-      npmInstall().path / "node_modules" / "rollup" / "dist" / "bin" / "rollup"
+    for path <- os.list(npmInstall().path) do
+      os.remove(Task.dest / path.last)
+      os.symlink(Task.dest / path.last, path)
 
     try
       os.call(
         Seq(
-          "node",
-          rollupPath.toString,
+          "npx",
+          "rollup",
           copied.head.path.toString
         ) ++ rollupCliArgs(),
         cwd = Task.dest

--- a/millbundler/src/io/github/nafg/millbundler/ScalaJSWebpackModule.scala
+++ b/millbundler/src/io/github/nafg/millbundler/ScalaJSWebpackModule.scala
@@ -93,12 +93,14 @@ trait ScalaJSWebpackModule extends ScalaJSBundleModule {
       configPath,
       webpackConfig(Task.dest, params, bundleFilename(), webpackLibraryName())
     )
-    val webpackPath =
-      npmInstall().path / "node_modules" / "webpack" / "bin" / "webpack"
+
+    for path <- os.list(npmInstall().path) do
+      os.remove(Task.dest / path.last)
+      os.symlink(Task.dest / path.last, path)
 
     try
       os.call(
-        Seq("node", webpackPath.toString, "--config", configPath.toString),
+        Seq("npx", "webpack", "--config", configPath.toString),
         env = webpackEnv(),
         cwd = Task.dest
       )


### PR DESCRIPTION
I've tried the current master branch and found that it fails to resolve js dependencies completely. The dependencies are installed in the respective node_modules directories and listed in package.json, but the way rollup and webpack are run, they fail to find them.

I did not find any command line options of npm/npx nor webpack/rollup to fix this. So my solution is to symlink the contents of npmInstall.dest into bundle.dest and then run webpack/rollup using npx.

I'm not sure this works on windows, but the code uses symlinks already, so I've assumed it is fine, and in theory at least, windows supports symlinks.

Maybe there's a better solution, but as I had to get this running anyway, I wanted to share it.