### PR TITLE
fix(publishing): cross-publish for mill 1.x and 0.12.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
             command: ./mill
           - name: windows-latest
             command: .\mill.bat
+        mill-version:
+          - 1.0.6
+          - 0.12.5
 
     runs-on: ${{ matrix.os.name }}
 
@@ -30,6 +33,8 @@ jobs:
           jvm: temurin:17
 
       - name: Test
+        env:
+          MILL_VERSION: ${{ matrix.mill-version }}
         run: |
           ${{ matrix.os.command }} --no-server --jobs 0 _.test
 
@@ -42,6 +47,12 @@ jobs:
           report_paths: 'out/**/test-report.xml'
 
   publish:
+    strategy:
+      matrix:
+        mill-version:
+          - 1.0.6
+          - 0.12.5
+
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
@@ -60,3 +71,4 @@ jobs:
           MILL_PGP_SECRET_BASE64: ${{ secrets.PGP_SECRET }}
           MILL_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           MILL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          MILL_VERSION: ${{ matrix.mill-version }}

--- a/.mill-version
+++ b/.mill-version
@@ -1,1 +1,1 @@
-1.0.4-native
+1.0.6-native

--- a/build.mill
+++ b/build.mill
@@ -4,7 +4,7 @@
 
 import mill.*
 import mill.contrib.buildinfo.BuildInfo
-import mill.constants.BuildInfo.millVersion
+import mill.constants.BuildInfo.{millVersion, millBinPlatform}
 import mill.scalalib.*
 import mill.scalalib.publish.*
 import mill.scalalib.scalafmt.*
@@ -22,7 +22,9 @@ trait BasePublishModule
     extends BaseScalaModule
     with SonatypeCentralPublishModule
     with ScalafmtModule {
-  override def scalaVersion = "3.7.2"
+
+  // Set the `platformSuffix` so the name indicates what Mill version it is compiled for
+  def platformSuffix = s"_mill$millBinPlatform"
 
   override def publishVersion: T[String] =
     VcsVersion


### PR DESCRIPTION
This obsoletes #7 - mill plugins now need to have the build major version as part of the name. 

The current error with mill 1.0.6 and 0.3.0 of the plugin is:

```
[build.mill-52] resolvedRunMvnDeps java.lang.RuntimeException:
Resolution failed for 1 modules:
--------------------------------------------
  io.github.nafg.millbundler:millbundler_mill1_3:0.3.0
        Not an internal Mill module: io.github.nafg.millbundler:millbundler_mill1_3:0.3.0
```